### PR TITLE
fix: improve error outline color

### DIFF
--- a/packages/orbi-chakra-theme/src/colors.ts
+++ b/packages/orbi-chakra-theme/src/colors.ts
@@ -68,7 +68,7 @@ export const accentBlueTokens = {
 export const stateColors = {
   "state.error": {
     default: "#fc0f0f",
-    _dark: "#c90101",
+    _dark: "#f55f4e",
   },
   "state.success": {
     default: "#32ff6f",

--- a/packages/orbi-chakra-theme/src/components/input.ts
+++ b/packages/orbi-chakra-theme/src/components/input.ts
@@ -76,7 +76,7 @@ function getDefaults(props: Record<string, any>) {
   };
 }
 
-const variantOutline = definePartsStyle(props => {
+const variantOutline = definePartsStyle((props) => {
   const { focusBorderColor: fc, errorBorderColor: ec } = getDefaults(props);
 
   return {
@@ -109,7 +109,7 @@ const variantOutline = definePartsStyle(props => {
   };
 });
 
-const variantFilled = definePartsStyle(props => {
+const variantFilled = definePartsStyle((props) => {
   const { focusBorderColor: fc, errorBorderColor: ec } = getDefaults(props);
 
   return {
@@ -140,7 +140,7 @@ const variantFilled = definePartsStyle(props => {
   };
 });
 
-const variantFlushed = definePartsStyle(props => {
+const variantFlushed = definePartsStyle((props) => {
   const { theme } = props;
   const { focusBorderColor: fc, errorBorderColor: ec } = getDefaults(props);
 


### PR DESCRIPTION
## 📑 Description
Make the error outline background color a bit lighter/more subtle in dark mode. PFA screenshots
Before:
<img width="1211" alt="image" src="https://user-images.githubusercontent.com/66675022/188697232-f9d98b05-1613-4480-a6b2-48cd1d214249.png">

After:
<img width="1218" alt="image" src="https://user-images.githubusercontent.com/66675022/188697304-fc8ea8a6-4b28-4078-879e-1d8b0deeafce.png">


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
